### PR TITLE
CI Readiness

### DIFF
--- a/build-release-driver.bat
+++ b/build-release-driver.bat
@@ -1,0 +1,4 @@
+msbuild sys\windivertdriver.vcxproj ^
+    /p:Configuration=Release ^
+    /p:Platform=x64 ^
+    /p:OutDir=..\output\x64\Release\

--- a/build-release-wdna.bat
+++ b/build-release-wdna.bat
@@ -1,0 +1,9 @@
+msbuild dll\windivert.vcxproj ^
+    /p:Configuration=Release ^
+    /p:Platform=x64 ^
+    /p:OutDir=..\output\x64\Release\
+
+msbuild examples\wdna\wdna.vcxproj ^
+    /p:Configuration=Release ^
+    /p:Platform=x64 ^
+    /p:OutDir=..\..\output\x64\Release\

--- a/dll/windivert.vcxproj
+++ b/dll/windivert.vcxproj
@@ -71,10 +71,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)\output\$(Platform)\$(Configuration)\</OutDir>
     <TargetName>WinDivert</TargetName>
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)\output\$(Platform)\$(Configuration)\</OutDir>
     <TargetName>WinDivert</TargetName>
+    <PreBuildEventUseInBuild>false</PreBuildEventUseInBuild>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -89,13 +91,15 @@
       <AdditionalDependencies>%(AdditionalDependencies);</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>true</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>windivert.def</ModuleDefinitionFile>
-      <ImportLibrary>WinDivert.lib</ImportLibrary>
+      <ImportLibrary>$(OutDir)WinDivert.lib</ImportLibrary>
       <AdditionalLibraryDirectories Condition="'$(Configuration)|$(Platform)'=='Release|x64'">%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">copy $(ProjectDir)WinDivert.lib $(outDir)</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">copy $(ProjectDir)WinDivert.lib $(outDir)</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
- using .bat files for scripts instead of .ps1 since .ps1 requires signing
- changed linker configuration so that it automatically generates the .lib file in the output directory
- no need for post build events
- .bat script to build the driver (Release configuration)
- .bat script to build the wdna (Release configuration)